### PR TITLE
ipmitool & automatic os-release generation

### DIFF
--- a/meta-yandex/meta-openrack/meta-shaosi/conf/local.conf.sample
+++ b/meta-yandex/meta-openrack/meta-shaosi/conf/local.conf.sample
@@ -244,4 +244,4 @@ EXTRA_USERS_PARAMS = " \
   usermod -p '\$1\$UGMqyqdG\$FZiylVFmRRfl9Z0Ue8G7e/' root; \
   "
 
-IMAGE_INSTALL_append = " luajit luajit-common lmsensors-sensors strace tcpdump dtoverlay ethtool iproute2 vlan iperf bridge-utils pyphosphor iotools openrack openresty lua-ipmi lua-dbus opkg jfauth pid3 "
+IMAGE_INSTALL_append = " luajit luajit-common lmsensors-sensors strace tcpdump dtoverlay ethtool iproute2 vlan iperf bridge-utils pyphosphor iotools openrack openresty lua-ipmi lua-dbus opkg jfauth pid3 host-ipmid-tool "

--- a/meta-yandex/meta-openrack/meta-shaosi/conf/local.conf.sample
+++ b/meta-yandex/meta-openrack/meta-shaosi/conf/local.conf.sample
@@ -244,4 +244,4 @@ EXTRA_USERS_PARAMS = " \
   usermod -p '\$1\$UGMqyqdG\$FZiylVFmRRfl9Z0Ue8G7e/' root; \
   "
 
-IMAGE_INSTALL_append = " luajit luajit-common lmsensors-sensors strace tcpdump dtoverlay ethtool iproute2 vlan iperf bridge-utils pyphosphor iotools openrack openresty lua-ipmi lua-dbus opkg jfauth pid3 host-ipmid-tool "
+IMAGE_INSTALL_append = " luajit luajit-common lmsensors-sensors strace tcpdump dtoverlay ethtool iproute2 vlan iperf bridge-utils pyphosphor iotools openrack openresty lua-ipmi lua-dbus opkg jfauth pid3 ipmitool "

--- a/meta-yandex/meta-openrack/meta-shaosi/recipes-phosphor/ipmitool/ipmitool.bb
+++ b/meta-yandex/meta-openrack/meta-shaosi/recipes-phosphor/ipmitool/ipmitool.bb
@@ -1,0 +1,30 @@
+SUMMARY = "Phosphor ipmi tool for injecting ipmi commands"
+DESCRIPTION = "IPMI Tool with dbus capabilities"
+HOMEPAGE = "https://github.com/openbmc/ipmitool"
+PR = "r1"
+
+
+inherit obmc-phosphor-license
+
+RDEPENDS_${PN} += "libcrypto "
+
+
+SRC_URI += "git://github.com/openbmc/ipmitool"
+
+SRCREV = "e9b9c1a9677a3de19726d036cfb07d8d61bbccd8"
+
+
+S = "${WORKDIR}/git"
+
+
+do_compile() {
+        ${S}/bootstrap 
+        ${S}/configure --host x86_64
+        make
+}
+
+do_install() {
+        install -m 0755 -d ${D}${sbindir}
+        install -m 0755 ${S}/src/ipmitool ${D}${sbindir}
+}
+

--- a/meta-yandex/meta-openrack/meta-shaosi/recipes-phosphor/os-release/os-release.bbappend
+++ b/meta-yandex/meta-openrack/meta-shaosi/recipes-phosphor/os-release/os-release.bbappend
@@ -9,11 +9,11 @@ python() {
         ver = None
         try:
             t = subprocess.check_output(['git', 'describe', '--tags']).rstrip()
-            ver = t.rsplit('-',2)[0]
-            ver = re.sub('[^0-9.-]','',ver)
-            if ver and t:
-                short_ver = '0.1.0-' + ver
-                long_ver  = 'OpenBMC:' + d.getVar('VERSION_ID',True) + " Yandex:0.1.0-" + t
+            if t:
+                arrv = t.rsplit('-',2)
+                short_ver = re.sub('[^0-9.-]','',arrv[0])
+                short_ver = short_ver + '-' + arrv[1] + '-' + arrv[2]
+                long_ver  = 'OpenBMC:' + d.getVar('VERSION_ID',True) + " Yandex:" + short_ver
                 d.setVar('VERSION', short_ver)
                 d.setVar('VERSION_ID', long_ver)
                 d.setVar('BUILD_ID', d.getVar('DATETIME'))

--- a/meta-yandex/meta-openrack/meta-shaosi/recipes-phosphor/os-release/os-release.bbappend
+++ b/meta-yandex/meta-openrack/meta-shaosi/recipes-phosphor/os-release/os-release.bbappend
@@ -13,7 +13,7 @@ python() {
                 arrv = t.rsplit('-',2)
                 short_ver = re.sub('[^0-9.-]','',arrv[0])
                 short_ver = short_ver + '-' + arrv[1] + '-' + arrv[2]
-                long_ver  = 'OpenBMC:' + d.getVar('VERSION_ID',True) + " Yandex:" + short_ver
+                long_ver  = d.getVar('VERSION_ID',True) + '+' + short_ver
                 d.setVar('VERSION', short_ver)
                 d.setVar('VERSION_ID', long_ver)
                 d.setVar('BUILD_ID', d.getVar('DATETIME'))

--- a/meta-yandex/meta-openrack/meta-shaosi/recipes-phosphor/os-release/os-release.bbappend
+++ b/meta-yandex/meta-openrack/meta-shaosi/recipes-phosphor/os-release/os-release.bbappend
@@ -1,14 +1,23 @@
 python() {
         import os
-        v = None
-        p = d.getVar("LAYER_DIR",True) + "/conf/build.id"
+        import subprocess
+        import re
+
+        cwd = os.getcwd()
+        os.chdir(d.getVar("LAYER_DIR",True))
+        t = None
+        ver = None
         try:
-            with open(p, 'r') as f:
-                v = f.read().rstrip('\n')
-            if v:
-                d.setVar('VERSION', '0.1.0-%s' % v)
-                d.setVar('VERSION_ID', '0.1.0-%s' % v)
+            t = subprocess.check_output(['git', 'describe', '--tags']).rstrip()
+            ver = t.rsplit('-',2)[0]
+            ver = re.sub('[^0-9.-]','',ver)
+            if ver and t:
+                short_ver = '0.1.0-' + ver
+                long_ver  = 'OpenBMC:' + d.getVar('VERSION_ID',True) + " Yandex:0.1.0-" + t
+                d.setVar('VERSION', short_ver)
+                d.setVar('VERSION_ID', long_ver)
                 d.setVar('BUILD_ID', d.getVar('DATETIME'))
         except:
-            pass
+           pass
+        os.chdir(cwd)
 }


### PR DESCRIPTION
1. Returned ipmitool (host-ipmid-tool) back for manual on-host diagnostics;
2. Changed os-release generation. No need to edit build.id file anymore, just add tag with version when releasing. Also added more information to VERSION_ID. Now it contains version and commit hash of both openbmc and meta-yandex, like that: 
openbmc:v1.99.0-309-ged181d5-dirty_yandex:0.1.0-b8.11-1-g25af0ef